### PR TITLE
Remove ENABLE_EVM_RPC configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ It's designed to work with [central-proxy-docker](https://github.com/CryptoManuf
     *   `CHAIN`: Set to "Mainnet" or "Testnet".
     *   `USERNAME`: Username for the node container (default: `hyperliquid`).
     *   `NODE_TYPE`: Set to "non-validator" or "validator".
-    *   `ENABLE_EVM_RPC`: Set to `true` to enable the `--serve-eth-rpc` flag (default: `true`).
     *   `P2P_PORT_RANGE`: Port range for P2P communication (default: `4000-4010`).
     *   `EVM_RPC_PORT`: Port for ETH RPC access (default: `3001`).
     *   `COMPOSE_FILE`: Add other compose files like `:rpc-shared.yml` or `:ext-network.yml` as needed.

--- a/default.env
+++ b/default.env
@@ -5,7 +5,6 @@ CHAIN=Mainnet
 USERNAME=hyperliquid
 NODE_TYPE=
 VALIDATOR_PRIVATE_KEY=
-ENABLE_EVM_RPC=true
 
 # Port configuration
 P2P_PORT_RANGE=4000-4010

--- a/hyperliquid.yml
+++ b/hyperliquid.yml
@@ -22,7 +22,6 @@ services:
       - CHAIN=${CHAIN:-Mainnet}
       - NODE_TYPE=${NODE_TYPE:-non-validator}
       - LOG_LEVEL=${LOG_LEVEL:-info}
-      - ENABLE_EVM_RPC=${ENABLE_EVM_RPC:-false}
       - VALIDATOR_PRIVATE_KEY=${VALIDATOR_PRIVATE_KEY:-}
       - MAINNET_ROOT_IPS=${MAINNET_ROOT_IPS:-}
       - TESTNET_ROOT_IPS=${TESTNET_ROOT_IPS:-}
@@ -119,7 +118,6 @@ services:
       - CHAIN=${CHAIN:-Mainnet}
       - NODE_TYPE=${NODE_TYPE:-non-validator}
       - LOG_LEVEL=${LOG_LEVEL:-info}
-      - ENABLE_EVM_RPC=${ENABLE_EVM_RPC:-false}
       - VALIDATOR_PRIVATE_KEY=${VALIDATOR_PRIVATE_KEY:-}
       - MAINNET_ROOT_IPS=${MAINNET_ROOT_IPS:-}
       - TESTNET_ROOT_IPS=${TESTNET_ROOT_IPS:-}

--- a/hyperliquid/docker-entrypoint.sh
+++ b/hyperliquid/docker-entrypoint.sh
@@ -93,10 +93,6 @@ fi
 # Base run command
 CMD="$HOME/hl-visor run-$NODE_TYPE"
 
-if [ "$ENABLE_EVM_RPC" = "true" ]; then
-  CMD="$CMD --serve-eth-rpc"
-fi
-
 if [ -n "$EXTRA_FLAGS" ]; then
   CMD="$CMD $EXTRA_FLAGS"
 fi


### PR DESCRIPTION
## Summary
This PR removes the ENABLE_EVM_RPC configuration option from the project.

## Changes
- Removed `ENABLE_EVM_RPC=true` from default.env
- Removed the logic that checks `ENABLE_EVM_RPC` and adds the `--serve-eth-rpc` flag in docker-entrypoint.sh
- Removed `ENABLE_EVM_RPC` environment variable from both consensus and cli services in hyperliquid.yml
- Updated README.md to remove ENABLE_EVM_RPC documentation

## Impact
The node will no longer have the option to enable EVM RPC functionality through the `--serve-eth-rpc` flag via environment variables.