### PR TITLE
BCE-10510: Upgrade Hyperliquid exporter monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,8 +426,7 @@ To visualize the metrics collected:
    Configure Prometheus to scrape metrics from your node's monitoring endpoint.
 
 2. **Import the dashboard:**
-   - Download the pre-configured Grafana dashboard from [hyperliquid-exporter/grafana/grafana.json](https://github.com/validaoxyz/hyperliquid-exporter/blob/main/grafana/grafana.json)
-   - In Grafana, go to Dashboard → Import and upload the JSON file
+   - Create or update a Grafana dashboard from the Prometheus metrics exposed by the monitoring service
    - Select your Prometheus data source
 
 ### Available Metrics

--- a/monitoring.yml
+++ b/monitoring.yml
@@ -27,7 +27,10 @@ services:
       - --alias=${NODE_ALIAS:-local}
       - --node-home=/home/hyperliquid/hl
       - --node-binary=/home/hyperliquid/hl-node
-      - --validator-rtt
+      - --metrics-port=${MONITORING_PORT:-8086}
+      - --probe-info-endpoint
+      - --info-endpoint-url=http://consensus:3001/info
+      # - --validator-rtt
     depends_on:
       - consensus
     <<: *logging

--- a/monitoring/Dockerfile
+++ b/monitoring/Dockerfile
@@ -1,15 +1,20 @@
 FROM golang:1.23.2-alpine3.20 AS builder
 
-RUN apk add git
+ARG EXPORTER_VERSION=v3.0.0
+
+RUN apk add --no-cache git
 
 WORKDIR /app
 
 RUN git clone https://github.com/validaoxyz/hyperliquid-exporter.git .
-RUN git checkout v2.0.0
+RUN git checkout "${EXPORTER_VERSION}"
 
 RUN go mod download
 RUN mkdir ./bin
-RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o ./bin/hl_exporter ./cmd/hl-exporter
+RUN GIT_COMMIT="$(git rev-parse --short HEAD)" && \
+    GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build \
+      -ldflags "-X github.com/validaoxyz/hyperliquid-exporter/internal/metrics.BuildVersion=${EXPORTER_VERSION} -X github.com/validaoxyz/hyperliquid-exporter/internal/metrics.BuildCommit=${GIT_COMMIT}" \
+      -o ./bin/hl_exporter ./cmd/hl-exporter
 
 FROM ubuntu:24.04
 WORKDIR /app


### PR DESCRIPTION
## Summary
- bump Hyperliquid monitoring exporter pin from v2.0.0 to v3.0.0
- add exporter build metadata and v3 health/info probe flags
- keep --validator-rtt present but commented for current non-validator mode
- remove stale README instruction pointing at the removed upstream Grafana JSON

## Validation
- git diff --check
- CHAIN=Mainnet docker compose -f hyperliquid.yml -f monitoring.yml config
- upstream validaoxyz/hyperliquid-exporter v3.0.0: go test ./...
- direct v3 exporter build and version check

## Notes
- Local Docker image build was not run because the local Docker daemon is unavailable.
- Grafana dashboard e149ac6b-f518-406d-a112-bd57460b02e5 was updated separately to version 94 with v3-compatible query fixes.