### PR TITLE
Add AQA publisher support with configuration and Docker setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ validator-publisher/*.local.json
 validator-publisher/logs/
 validator-publisher/state/
 validator-publisher/tmp/
+aqa-publisher/.env
+aqa-publisher/logs/
 hyperliquid-data/
 *.crt
 *-dev

--- a/README.md
+++ b/README.md
@@ -144,6 +144,81 @@ The container runs the official publisher Visor with:
 
 Logs and local state are stored in named Docker volumes. Outcome voting does not submit validator actions directly; it posts candidate outcome deploy and settle actions to Slack for validator review.
 
+## AQA Publisher
+
+This repository also includes an optional `aqa-publisher` compose file for publishing the Hyperliquid aligned quote asset rate. The upstream reference implementation is here:
+https://github.com/native-markets/aqa-publisher
+
+Hyperliquid recommends active validators publish the AQA rate once per day at 22:00 UTC from a separate machine from the validating node. It is fine to run this on the same non-validator publisher host as `validator-publisher`.
+
+### Runtime Requirements
+
+Prepare the following values outside git:
+
+- A dedicated AQA publisher agent private key approved by the validator.
+- Network set to `mainnet`.
+
+The AQA publisher image builds the upstream `native-markets/aqa-publisher` source from `v1.2.0`, which upstream currently marks as the supported release. The default service runs `publish_daemon`; tool-profile services are available for `print_current` and `publish_once`.
+
+### Configuration
+
+On a host that runs only AQA publisher, set:
+
+```env
+COMPOSE_FILE=aqa-publisher.yml
+```
+
+On the shared publisher host that runs both publisher sidecars, set:
+
+```env
+COMPOSE_FILE=validator-publisher.yml:aqa-publisher.yml
+```
+
+Populate the AQA variables in `.env`:
+
+```env
+AQA_PUBLISHER_VERSION=v1.2.0
+AQA_PUBLISHER_PRIVATE_KEY=
+AQA_PUBLISHER_NETWORK=mainnet
+AQA_PUBLISHER_RUST_LOG=info
+```
+
+The compose file maps these to the upstream environment variables:
+
+```env
+PUBLISHER_PRIVATE_KEY=${AQA_PUBLISHER_PRIVATE_KEY}
+NETWORK=${AQA_PUBLISHER_NETWORK}
+RUST_LOG=${AQA_PUBLISHER_RUST_LOG}
+```
+
+### Run
+
+Build and start the daemon:
+
+```bash
+docker compose -f aqa-publisher.yml build --pull
+docker compose -f aqa-publisher.yml up -d
+```
+
+Check status and logs:
+
+```bash
+docker compose -f aqa-publisher.yml ps
+docker compose -f aqa-publisher.yml logs -f aqa-publisher
+```
+
+Run the read-only rate check:
+
+```bash
+docker compose -f aqa-publisher.yml --profile tools run --rm aqa-print-current
+```
+
+Run a one-off publish only after the approved AQA publisher key is configured:
+
+```bash
+docker compose -f aqa-publisher.yml --profile tools run --rm aqa-publish-once
+```
+
 ## Tools and Utilities
 
 This setup includes several utility tools for interacting with your Hyperliquid node and the network.

--- a/aqa-publisher.yml
+++ b/aqa-publisher.yml
@@ -1,0 +1,45 @@
+x-logging: &logging
+  logging:
+    driver: json-file
+    options:
+      max-size: 100m
+      max-file: "3"
+      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+
+x-aqa-publisher-build: &aqa-publisher-build
+  build:
+    context: .
+    dockerfile: aqa-publisher/Dockerfile
+    args:
+      - USERNAME=${AQA_PUBLISHER_USERNAME:-hyperliquid}
+      - AQA_PUBLISHER_VERSION=${AQA_PUBLISHER_VERSION:-v1.2.0}
+  image: hyperliquid-aqa-publisher:local
+  pull_policy: never
+
+x-aqa-publisher-environment: &aqa-publisher-environment
+  environment:
+    - AQA_PUBLISHER_PRIVATE_KEY=${AQA_PUBLISHER_PRIVATE_KEY:-}
+    - AQA_PUBLISHER_NETWORK=${AQA_PUBLISHER_NETWORK:-mainnet}
+    - AQA_PUBLISHER_RUST_LOG=${AQA_PUBLISHER_RUST_LOG:-info}
+    - PUBLISHER_PRIVATE_KEY=${AQA_PUBLISHER_PRIVATE_KEY:-}
+    - NETWORK=${AQA_PUBLISHER_NETWORK:-mainnet}
+    - RUST_LOG=${AQA_PUBLISHER_RUST_LOG:-info}
+
+services:
+  aqa-publisher:
+    <<: [*aqa-publisher-build, *aqa-publisher-environment, *logging]
+    restart: unless-stopped
+    command:
+      - publish_daemon
+
+  aqa-print-current:
+    <<: [*aqa-publisher-build, *aqa-publisher-environment, *logging]
+    profiles: ["tools"]
+    command:
+      - print_current
+
+  aqa-publish-once:
+    <<: [*aqa-publisher-build, *aqa-publisher-environment, *logging]
+    profiles: ["tools"]
+    command:
+      - publish_once

--- a/aqa-publisher/Dockerfile
+++ b/aqa-publisher/Dockerfile
@@ -1,0 +1,48 @@
+FROM rust:1.91-slim AS builder
+
+ARG AQA_PUBLISHER_VERSION=v1.2.0
+
+RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    ca-certificates \
+    git \
+    libssl-dev \
+    pkg-config \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+RUN git clone --depth 1 --branch "${AQA_PUBLISHER_VERSION}" https://github.com/native-markets/aqa-publisher.git .
+
+RUN cargo build --release --locked \
+    --bin publish_daemon \
+    --bin publish_once \
+    --bin print_current
+
+FROM debian:bookworm-slim
+
+ARG USERNAME=hyperliquid
+
+RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libssl3 \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --create-home --shell /usr/sbin/nologin "${USERNAME}"
+
+COPY --from=builder /build/target/release/publish_daemon /usr/local/bin/publish_daemon
+COPY --from=builder /build/target/release/publish_once /usr/local/bin/publish_once
+COPY --from=builder /build/target/release/print_current /usr/local/bin/print_current
+COPY aqa-publisher/docker-entrypoint.sh /usr/local/bin/aqa-publisher-entrypoint.sh
+
+RUN chmod 0755 \
+    /usr/local/bin/publish_daemon \
+    /usr/local/bin/publish_once \
+    /usr/local/bin/print_current \
+    /usr/local/bin/aqa-publisher-entrypoint.sh
+
+USER ${USERNAME}
+WORKDIR /home/${USERNAME}
+
+ENTRYPOINT ["/usr/local/bin/aqa-publisher-entrypoint.sh"]

--- a/aqa-publisher/docker-entrypoint.sh
+++ b/aqa-publisher/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -n "${AQA_PUBLISHER_PRIVATE_KEY:-}" ]; then
+  export PUBLISHER_PRIVATE_KEY="${AQA_PUBLISHER_PRIVATE_KEY}"
+fi
+
+export NETWORK="${AQA_PUBLISHER_NETWORK:-${NETWORK:-mainnet}}"
+export RUST_LOG="${AQA_PUBLISHER_RUST_LOG:-${RUST_LOG:-info}}"
+
+exec "$@"

--- a/default.env
+++ b/default.env
@@ -80,6 +80,15 @@ VALIDATOR_PUBLISHER_SLACK_ERRORS_CHANNEL=
 VALIDATOR_PUBLISHER_SLACK_OUTCOME_ACTIONS_CHANNEL=
 VALIDATOR_PUBLISHER_CRIT_MSG_IGNORES='[]'
 
+# AQA publisher configuration.
+# Use this on a non-validator publisher host with COMPOSE_FILE=aqa-publisher.yml
+# or alongside validator-publisher with COMPOSE_FILE=validator-publisher.yml:aqa-publisher.yml.
+AQA_PUBLISHER_VERSION=v1.2.0
+AQA_PUBLISHER_USERNAME=hyperliquid
+AQA_PUBLISHER_PRIVATE_KEY=
+AQA_PUBLISHER_NETWORK=mainnet
+AQA_PUBLISHER_RUST_LOG=info
+
 # Expose using traefik
 DOCKER_EXT_NETWORK=traefik_default
 ENV_VERSION=1


### PR DESCRIPTION
Introduce support for the AQA publisher, including configuration details and a Docker setup for publishing the Hyperliquid aligned quote asset rate. This addition allows active validators to publish the AQA rate efficiently.