### PR TITLE
Fix validator publisher runtime binary layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The container runs the official publisher Visor with:
 --acked-outcome-vote-actions-path /opt/validator-publisher/state/acked_outcome_vote_actions.json
 ```
 
-Logs and local state are stored in named Docker volumes. Outcome voting does not submit validator actions directly; it posts candidate outcome deploy and settle actions to Slack for validator review.
+Logs and local state are stored in named Docker volumes. The Visor and downloaded child binaries live under `/opt/validator-publisher/bin`, and temporary files stay under `/opt/validator-publisher/tmp` on the same writable container filesystem so Visor updates can move files atomically. Outcome voting does not submit validator actions directly; it posts candidate outcome deploy and settle actions to Slack for validator review.
 
 ## AQA Publisher
 

--- a/validator-publisher.yml
+++ b/validator-publisher.yml
@@ -48,10 +48,8 @@ services:
     volumes:
       - validator-publisher-logs:/opt/validator-publisher/logs
       - validator-publisher-state:/opt/validator-publisher/state
-      - validator-publisher-tmp:/opt/validator-publisher/tmp
     <<: *logging
 
 volumes:
   validator-publisher-logs:
   validator-publisher-state:
-  validator-publisher-tmp:

--- a/validator-publisher/Dockerfile
+++ b/validator-publisher/Dockerfile
@@ -9,14 +9,16 @@ RUN apt-get update \
 
 RUN useradd --create-home --shell /usr/sbin/nologin "${USERNAME}" \
   && mkdir -p \
+    /opt/validator-publisher/bin \
     /opt/validator-publisher/config \
     /opt/validator-publisher/logs \
     /opt/validator-publisher/state \
     /opt/validator-publisher/tmp \
   && chown -R "${USERNAME}:${USERNAME}" /opt/validator-publisher
 
-RUN curl -fsSL "${VALIDATOR_PUBLISHER_VISOR_URL}" -o /usr/local/bin/validator-publisher-visor \
-  && chmod 0755 /usr/local/bin/validator-publisher-visor
+RUN curl -fsSL "${VALIDATOR_PUBLISHER_VISOR_URL}" -o /opt/validator-publisher/bin/validator-publisher-visor \
+  && chmod 0755 /opt/validator-publisher/bin/validator-publisher-visor \
+  && chown "${USERNAME}:${USERNAME}" /opt/validator-publisher/bin/validator-publisher-visor
 
 COPY validator-publisher/docker-entrypoint.sh /usr/local/bin/validator-publisher-entrypoint.sh
 COPY scripts/render_validator_publisher_config.sh /usr/local/bin/render_validator_publisher_config.sh

--- a/validator-publisher/docker-entrypoint.sh
+++ b/validator-publisher/docker-entrypoint.sh
@@ -5,4 +5,4 @@ set -euo pipefail
 export VALIDATOR_PUBLISHER_CONFIG_PATH
 
 render_validator_publisher_config.sh /dev/null
-exec validator-publisher-visor "$@"
+exec /opt/validator-publisher/bin/validator-publisher-visor "$@"


### PR DESCRIPTION
## Summary
- move the validator publisher visor into the writable /opt/validator-publisher/bin runtime directory
- remove the separate tmp volume so visor temporary files and child binaries stay on the same filesystem
- document the runtime layout and keep logs/state as named volumes