### PR TITLE
feat: BCE-10596 - sentry split_client_blocks gossip toggle

### DIFF
--- a/default.env
+++ b/default.env
@@ -40,6 +40,12 @@ FIREWALL_IPS='[]'
 # SENTRY_IPS='["1.2.3.4", "5.6.7.8"]'
 SENTRY_IPS='[]'
 
+# Sentry toggle. Set to true ONLY on sentry nodes.
+# When true, the entrypoint sets "split_client_blocks": true in
+# ~/override_gossip_config.json. Gated on this lever (not NODE_TYPE) because a
+# validator host is sometimes run as a non-validator.
+SENTRY=false
+
 # Monitoring
 NODE_ALIAS=local
 MONITORING_PORT=8086

--- a/hyperliquid.yml
+++ b/hyperliquid.yml
@@ -21,6 +21,7 @@ services:
     environment:
       - CHAIN=${CHAIN:-Mainnet}
       - NODE_TYPE=${NODE_TYPE:-non-validator}
+      - SENTRY=${SENTRY:-false}
       - LOG_LEVEL=${LOG_LEVEL:-info}
       - VALIDATOR_PRIVATE_KEY=${VALIDATOR_PRIVATE_KEY:-}
       - ENABLE_EVM_RPC=${ENABLE_EVM_RPC:-false}
@@ -151,6 +152,7 @@ services:
     environment:
       - USERNAME=${USERNAME:-hyperliquid}
       - CHAIN=${CHAIN:-Mainnet}
+      - SENTRY=${SENTRY:-false}
       - MAINNET_ROOT_IPS=${MAINNET_ROOT_IPS:-}
       - TESTNET_ROOT_IPS=${TESTNET_ROOT_IPS:-}
       - RESERVED_PEER_IPS=${RESERVED_PEER_IPS:-}
@@ -254,8 +256,31 @@ services:
           fi
         }
 
+        # Sentry-only: enable split_client_blocks in the gossip override
+        # (same logic as docker-entrypoint.sh). Gated on SENTRY, not NODE_TYPE.
+        apply_sentry_gossip() {
+          if [ "$${SENTRY:-false}" != "true" ]; then
+            return 0
+          fi
+          if [ -f "$$HOME/override_gossip_config.json" ]; then
+            tmp_gossip=$$(mktemp)
+            if jq '. + {split_client_blocks: true}' "$$HOME/override_gossip_config.json" > "$$tmp_gossip"; then
+              mv "$$tmp_gossip" "$$HOME/override_gossip_config.json"
+              echo "✅ Sentry mode: set split_client_blocks=true in override_gossip_config.json"
+            else
+              rm -f "$$tmp_gossip"
+              echo "❌ Error: failed to set split_client_blocks in override_gossip_config.json"
+              return 1
+            fi
+          else
+            echo '{ "split_client_blocks": true }' > "$$HOME/override_gossip_config.json"
+            echo "✅ Sentry mode: created override_gossip_config.json with split_client_blocks=true"
+          fi
+        }
+
         # Apply configurations
         create_gossip_config
+        apply_sentry_gossip
         create_firewall_config
         create_slack_config
 

--- a/hyperliquid/docker-entrypoint.sh
+++ b/hyperliquid/docker-entrypoint.sh
@@ -4,6 +4,11 @@ set -e
 # Default node type
 : "${NODE_TYPE:=non-validator}"
 
+# Sentry toggle. Set SENTRY=true (via the env file) only on sentry nodes.
+# We gate on SENTRY rather than NODE_TYPE because a validator host is sometimes
+# run as a non-validator, so NODE_TYPE cannot reliably distinguish a sentry.
+: "${SENTRY:=false}"
+
 # Create override_gossip_config.json
 if [ "${CHAIN}" = "Mainnet" ]; then
   if [ -n "$MAINNET_ROOT_IPS" ] && [ "$MAINNET_ROOT_IPS" != "[]" ]; then
@@ -28,6 +33,28 @@ EOF
   else
     echo "Info: Using default peers for CHAIN=Testnet" >&2
     rm -f "$HOME"/override_gossip_config.json
+  fi
+fi
+
+# Sentry-only: enable split_client_blocks in the gossip override.
+# Gated on SENTRY (not NODE_TYPE) so it applies to a sentry even when the host
+# is run as a non-validator. This runs after the gossip config is written above
+# and merges the field in, leaving the existing root_node_ips/peers untouched.
+if [ "$SENTRY" = "true" ]; then
+  if [ -f "$HOME/override_gossip_config.json" ]; then
+    tmp_gossip="$(mktemp)"
+    if jq '. + {split_client_blocks: true}' "$HOME/override_gossip_config.json" > "$tmp_gossip"; then
+      mv "$tmp_gossip" "$HOME/override_gossip_config.json"
+      echo "✅ Sentry mode: set split_client_blocks=true in override_gossip_config.json"
+    else
+      rm -f "$tmp_gossip"
+      echo "❌ Error: failed to set split_client_blocks in override_gossip_config.json" >&2
+      exit 1
+    fi
+  else
+    # No override file (e.g. Testnet using default peers) — create a minimal one.
+    echo '{ "split_client_blocks": true }' > "$HOME/override_gossip_config.json"
+    echo "✅ Sentry mode: created override_gossip_config.json with split_client_blocks=true"
   fi
 fi
 


### PR DESCRIPTION
## What
- Add `SENTRY` env lever (default `false`) to mark sentry nodes
- Entrypoint sets `"split_client_blocks": true` in `override_gossip_config.json` when `SENTRY=true`
- Mirror the same logic in the `config-sync` service so re-syncs do not drop it
- Gate on `SENTRY` not `NODE_TYPE`, since a validator host is sometimes run as a non-validator
- Document the `SENTRY` toggle in `default.env`

### Ticket
[BCE-10596](https://galaxydig.atlassian.net/browse/BCE-10596)

🤖 Generated with [Claude Code](https://claude.com/claude-code)